### PR TITLE
Better scratch file support

### DIFF
--- a/plugin/src/main/kotlin/com/github/bric3/excalidraw/actions/ToggleLightDarkModeAction.kt
+++ b/plugin/src/main/kotlin/com/github/bric3/excalidraw/actions/ToggleLightDarkModeAction.kt
@@ -1,0 +1,34 @@
+package com.github.bric3.excalidraw.actions
+
+import com.github.bric3.excalidraw.SceneModes
+import com.github.bric3.excalidraw.findEditor
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.util.ui.UIUtil
+
+class ToggleLightDarkModeAction() : ToggleSceneModeAction() {
+
+    override fun setSelected(event: AnActionEvent, state: Boolean) {
+        val sceneModes = event.getSceneModes() ?: return
+
+        toggle(sceneModes, state)
+
+        // This SceneMode value gets passed to a different
+        // method than other scene mode toggles
+
+        var mode = "dark";
+        if(state)
+            mode = "light"
+
+        event.findEditor()!!.viewController.changeTheme(mode)
+    }
+
+    override fun toggle(sceneModes: SceneModes, state: Boolean) {
+        sceneModes.lightMode = state
+    }
+
+    // Default selected state is dervived from the UI theme
+    // if user has not set a state
+    override fun isSelected(event: AnActionEvent): Boolean =
+        event.getSceneModes()?.lightMode ?: !UIUtil.isUnderDarcula()
+
+}

--- a/plugin/src/main/kotlin/com/github/bric3/excalidraw/excalidraw-options.kt
+++ b/plugin/src/main/kotlin/com/github/bric3/excalidraw/excalidraw-options.kt
@@ -16,6 +16,7 @@ data class SceneModes(
     var gridMode: Boolean? = null,
     var zenMode: Boolean? = null,
     var readOnlyMode: Boolean? = null,
+    var lightMode: Boolean? = null, // allow overriding uiTheme for the editor window
 ) {
     companion object {
         val SCENE_MODES_KEY: Key<SceneModes> = Key.create(SceneModes::javaClass.name)

--- a/plugin/src/main/kotlin/com/github/bric3/excalidraw/files/ExcalidrawFileType.kt
+++ b/plugin/src/main/kotlin/com/github/bric3/excalidraw/files/ExcalidrawFileType.kt
@@ -14,4 +14,6 @@ object ExcalidrawFileType : LanguageFileType(ExcalidrawJson, true)
     override fun getDescription() = "Excalidraw sketch file"
     override fun getDefaultExtension() = "excalidraw"
     override fun getIcon() = ExcalidrawIcons.ExcalidrawFileIcon
+    override fun getDisplayName() = "Excalidraw sketch"
+    override fun isSecondary() = false
 }

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -81,6 +81,11 @@
                 text="Toggle Zen Mode"
                 description="Toggle the zen mode"
                 icon="AllIcons.General.ReaderMode"/>
+        <action id="excalidraw.ToggleLightDarkMode"
+                class="com.github.bric3.excalidraw.actions.ToggleLightDarkModeAction"
+                text="Toggle Light/Dark Mode"
+                description="Toggle Light/Dark mode"
+                icon="AllIcons.Actions.IntentionBulb"/>
 
         <!-- AllIcons.Actions.InlayGlobe -->
 
@@ -98,6 +103,7 @@
             <separator/>
             <reference ref="excalidraw.ToggleGridMode" />
             <reference ref="excalidraw.ToggleZenMode" />
+            <reference ref="excalidraw.ToggleLightDarkMode" />
         </group>
 
     </actions>

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -10,6 +10,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <fileType name="Excalidraw sketch"
                   implementationClass="com.github.bric3.excalidraw.files.ExcalidrawFileType"
+                  language="Excalidraw"
                   fieldName="INSTANCE"
                   extensions="excalidraw;excalidraw.json"/>
 


### PR DESCRIPTION
Proposed solution for issue #90. Goal is to change the scratch menu to open the diagram editor directly instead of a JSON editor, without impacting the new file menu (which seems to pick the editor by default).