### PR TITLE
Open Excalidraw UI instead of JSON editor when creating sketch files

### DIFF
--- a/plugin/src/main/kotlin/com/github/bric3/excalidraw/files/ExcalidrawFileType.kt
+++ b/plugin/src/main/kotlin/com/github/bric3/excalidraw/files/ExcalidrawFileType.kt
@@ -14,4 +14,6 @@ object ExcalidrawFileType : LanguageFileType(ExcalidrawJson, true)
     override fun getDescription() = "Excalidraw sketch file"
     override fun getDefaultExtension() = "excalidraw"
     override fun getIcon() = ExcalidrawIcons.ExcalidrawFileIcon
+    override fun getDisplayName() = "Excalidraw sketch"
+    override fun isSecondary() = false
 }

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -10,6 +10,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <fileType name="Excalidraw sketch"
                   implementationClass="com.github.bric3.excalidraw.files.ExcalidrawFileType"
+                  language="Excalidraw"
                   fieldName="INSTANCE"
                   extensions="excalidraw;excalidraw.json"/>
 


### PR DESCRIPTION
Here is a proposed solution for issue #91. The idea is for the scratch menu(s) to default to the Excalidraw UI instead of JSON editor when creating new file.

